### PR TITLE
update image dep to 0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = "0.2.0"
 dependencies = [
  "atomic_chunks_mut 0.1.0 (git+https://github.com/jimblandy/atomic-chunks-mut.git?rev=6d43a652f5c4df3a191c9d29e9f5d60cc677c470)",
  "crossbeam 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -82,7 +82,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "image"
-version = "0.10.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -94,6 +94,7 @@ dependencies = [
  "num-rational 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -236,5 +237,10 @@ dependencies = [
 [[package]]
 name = "rustc-serialize"
 version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Jim Blandy <jimb@red-bean.com>"]
 [dependencies]
 crossbeam = "0.2.9"
 num = "0.1.34"
-image = "0.10.1"
+image = "0.10.4"
 
 [dependencies.atomic_chunks_mut]
 git = "https://github.com/jimblandy/atomic-chunks-mut.git"


### PR DESCRIPTION
Updated image from 0.10.1 to 0.10.4. It was generating compiler warnings (rustc 1.13.0) like 
```
warning: this expression will panic at run-time
   --> /home/pedro/.cargo/registry/src/github.com-1ecc6299db9ec823/image-0.10.1/./src/color.rs:115:17
    |
115 |             d = this[3];
    |                 ^^^^^^^ index out of bounds: the len is 3 but the index is 3
...
228 | define_colors! {
    | - in this macro invocation

warning: this expression will panic at run-time
   --> /home/pedro/.cargo/registry/src/github.com-1ecc6299db9ec823/image-0.10.1/./src/color.rs:113:17
    |
113 |             b = this[1];
    |                 ^^^^^^^ index out of bounds: the len is 1 but the index is 1
...
228 | define_colors! {
    | - in this macro invocation

warning: this expression will panic at run-time
   --> /home/pedro/.cargo/registry/src/github.com-1ecc6299db9ec823/image-0.10.1/./src/color.rs:114:17
    |

```